### PR TITLE
Tech 2201 fixes

### DIFF
--- a/maker_keeper/main.py
+++ b/maker_keeper/main.py
@@ -96,12 +96,12 @@ class MakerKeeper:
             self.lifecycle.terminate()
         else:
             results = self.sequencer.getNextJobs(self.network_id)
-            for address, success, calldata in results:
-                logging.info(f"Success: {success} | Address: {address} | Calldata: {calldata}")
-                self.execute(success, address, calldata)
+            for address, canWork, calldata in results:
+                logging.info(f"canWork: {canWork} | Address: {address} | Calldata: {calldata}")
+                self.execute(canWork, address, calldata)
 
-    def execute(self, success: bool, address: str, calldata: str):
-        if success:
+    def execute(self, canWork: bool, address: str, calldata: str):
+        if canWork:
             gas_strategy = GeometricGasPrice(
                 web3=self.web3,
                 initial_price=None,
@@ -121,7 +121,7 @@ class MakerKeeper:
                 logging.error("Failed to run exec on IJob!")
 
         else:
-            logging.info("No update available")
+            logging.info(f"No update available. canWork: {canWork}")
 
 
     @staticmethod

--- a/maker_keeper/main.py
+++ b/maker_keeper/main.py
@@ -132,10 +132,10 @@ class MakerKeeper:
 
                 if receipt is not None and receipt.successful:
                     logging.info("Exec on IJob done!")
-                # do not fail oracle job if it is mined.
+                # Capture the result of an oracleJob transaction and do not throw an error if it is mined.
                 elif receipt is None and "0xe717Ec34b2707fc8c226b34be5eae8482d06ED03" in log_contents and "mined successfully but generated no single log entry" in log_contents:
                     logging.info(f"Exec on IJob done with exceptions in job: {address}")
-                # do not fail flapJob when it is not ready to be executed.
+                # Capture the result of the flapJob transaction and do not throw an error, if the flapJob was not ready to be executed.
                 elif receipt is None and "0xc32506E9bB590971671b649d9B8e18CB6260559F" in log_contents and "execution reverted: Vow/insufficient-surplus" in log_contents:
                     logging.info(f"IJob, {address}, will not be executed due to 'Vow/insufficient-surplus'.")
                 else:


### PR DESCRIPTION
Tech-2201 The fixes implemented are workarounds for the OracleJob errors, and the FlapJob error. 
The Oracle job, at times will complete with some errors, and this is considered normal operation for the oracleJob, as not all OSMs get updated at the same time. pyMaker logs this as a failed transaction.
The flapJob contract has a bug, returning canWork() as True, when in fact it is false, and causing pymaker to log the transaction as a failed transaction.
For both cases, we capture the log stream from pymaker class ad handle it appropriately for each job.