### PR TITLE
TECH-2963 - Bumping Python to 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.9
 
 RUN groupadd -r maker && useradd --no-log-init -r -g maker maker
 


### PR DESCRIPTION
**Python 3.10** doesn't work due to next Exception in `pymaker`
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/pytz/lazy.py", line 3, in <module>
    from UserDict import DictMixin
ModuleNotFoundError: No module named 'UserDict'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/opt/maker/maker-keeper/maker_keeper/main.py", line 24, in <module>
    from pymaker.lifecycle import Lifecycle
  File "/opt/maker/maker-keeper/lib/pymaker/pymaker/lifecycle.py", line 24, in <module>
    import pytz
  File "/usr/local/lib/python3.10/site-packages/pytz/__init__.py", line 32, in <module>
    from pytz.lazy import LazyDict, LazyList, LazySet
  File "/usr/local/lib/python3.10/site-packages/pytz/lazy.py", line 5, in <module>
    from collections import Mapping as DictMixin
ImportError: cannot import name 'Mapping' from 'collections' (/usr/local/lib/python3.10/collections/__init__.py)
```

**Python 3.11** doesn't work due to next Exception in `pymaker`
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/maker/maker-keeper/maker_keeper/main.py", line 22, in <module>
    from web3 import Web3, HTTPProvider
  File "/usr/local/lib/python3.11/site-packages/web3/__init__.py", line 6, in <module>
    from eth_account import (
  File "/usr/local/lib/python3.11/site-packages/eth_account/__init__.py", line 1, in <module>
    from eth_account.account import (
  File "/usr/local/lib/python3.11/site-packages/eth_account/account.py", line 59, in <module>
    from eth_account.messages import (
  File "/usr/local/lib/python3.11/site-packages/eth_account/messages.py", line 26, in <module>
    from eth_account._utils.structured_data.hashing import (
  File "/usr/local/lib/python3.11/site-packages/eth_account/_utils/structured_data/hashing.py", line 9, in <module>
    from eth_abi import (
  File "/usr/local/lib/python3.11/site-packages/eth_abi/__init__.py", line 6, in <module>
    from eth_abi.abi import (  # NOQA
  File "/usr/local/lib/python3.11/site-packages/eth_abi/abi.py", line 1, in <module>
    from eth_abi.codec import (
  File "/usr/local/lib/python3.11/site-packages/eth_abi/codec.py", line 16, in <module>
    from eth_abi.decoding import (
  File "/usr/local/lib/python3.11/site-packages/eth_abi/decoding.py", line 14, in <module>
    from eth_abi.base import (
  File "/usr/local/lib/python3.11/site-packages/eth_abi/base.py", line 7, in <module>
    from .grammar import (
  File "/usr/local/lib/python3.11/site-packages/eth_abi/grammar.py", line 4, in <module>
    import parsimonious
  File "/usr/local/lib/python3.11/site-packages/parsimonious/__init__.py", line 9, in <module>
    from parsimonious.grammar import Grammar, TokenGrammar
  File "/usr/local/lib/python3.11/site-packages/parsimonious/grammar.py", line 14, in <module>
    from parsimonious.expressions import (Literal, Regex, Sequence, OneOf,
  File "/usr/local/lib/python3.11/site-packages/parsimonious/expressions.py", line 9, in <module>
    from inspect import getargspec
ImportError: cannot import name 'getargspec' from 'inspect' (/usr/local/lib/python3.11/inspect.py)
```


**Python 3.12** doesn't work due to next Exception in `pymaker`
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/maker/maker-keeper/maker_keeper/main.py", line 17, in <module>
    import requests
  File "/usr/local/lib/python3.12/site-packages/requests/__init__.py", line 43, in <module>
    import urllib3
  File "/usr/local/lib/python3.12/site-packages/urllib3/__init__.py", line 7, in <module>
    from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, connection_from_url
  File "/usr/local/lib/python3.12/site-packages/urllib3/connectionpool.py", line 11, in <module>
    from .exceptions import (
  File "/usr/local/lib/python3.12/site-packages/urllib3/exceptions.py", line 2, in <module>
    from .packages.six.moves.http_client import IncompleteRead as httplib_IncompleteRead
ModuleNotFoundError: No module named 'urllib3.packages.six.moves'
```