### PR TITLE
TECH-4674 - Increasing timeouts and making node failovers more explicit

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,2 +1,12 @@
 #!/usr/bin/env bash
-/opt/maker/maker-keeper/bin/maker-keeper --primary-eth-rpc-url ${PRIMARY_RPC_URL} --backup-eth-rpc-url ${BACKUP_RPC_URL} --eth-from ${ETHFROM} --eth-private-key ${ETHKEY} --sequencer-address ${SEQUENCER_ADDRESS} --network-id ${NETWORK_ID} --blocknative-api-key ${BLOCKNATIVE_KEY}
+/opt/maker/maker-keeper/bin/maker-keeper \
+    --primary-eth-rpc-url ${PRIMARY_RPC_URL} \
+    --primary-eth-rpc-timeout ${PRIMARY_RPC_TIMEOUT} \
+    --backup-eth-rpc-url ${BACKUP_RPC_URL} \
+    --backup-eth-rpc-timeout ${BACKUP_RPC_TIMEOUT} \
+    --eth-from ${ETHFROM} \
+    --eth-private-key ${ETHKEY} \
+    --sequencer-address ${SEQUENCER_ADDRESS} \
+    --network-id ${NETWORK_ID} \
+    --blocknative-api-key ${BLOCKNATIVE_KEY} \
+    --max-errors ${MAX_ERRORS}

--- a/deploy/prod/values.yaml
+++ b/deploy/prod/values.yaml
@@ -14,6 +14,8 @@ command: ["sh", "-c"]
 args: ["/opt/maker/maker-keeper/bin/run.sh"]
 serviceAccount:
   create: false
+podAnnotations:
+  reloader.stakater.com/auto: "true"
 ingress:
   enabled: false
 resources:
@@ -54,21 +56,33 @@ env:
     type: parameterStore
     name: backup-eth-rpc-url
     parameter_name: /eks/maker-prod/maker-keeper/backup-eth-rpc-url
+  PRIMARY_RPC_TIMEOUT:
+    type: kv
+    value: 120
+  BACKUP_RPC_TIMEOUT:
+    type: kv
+    value: 120
+  LOG_LEVEL:
+    type: kv
+    value: INFO
+  MAX_ERRORS:
+    type: kv
+    value: 100
 externalSecrets:
   clusterSecretStoreName: maker-prod
 livenessProbe:
   exec:
     command:
-    - /bin/sh
-    - -c
-    - ps -ef | grep /opt/maker/maker-keeper/bin/run.sh
+      - /bin/sh
+      - -c
+      - ps -ef | grep /opt/maker/maker-keeper/bin/run.sh
   initialDelaySeconds: 5
   periodSeconds: 30
 readinessProbe:
   exec:
     command:
-    - /bin/sh
-    - -c
-    - ps -ef | grep /opt/maker/maker-keeper/bin/run.sh
+      - /bin/sh
+      - -c
+      - ps -ef | grep /opt/maker/maker-keeper/bin/run.sh
   initialDelaySeconds: 5
   periodSeconds: 30


### PR DESCRIPTION
@jeannettemcd hi there. 
Please have a look on this PR and merge if it is fine (I will be on vacation as of Monday).
So basically what I suggest here is:
1. Expose timeouts as env vars so we could set them more easily
2. Increasing timeouts as I noticed 2 out of 3 exceptions we managed to catch hit the timeout
3. Enabling `reloader.stakater.com/auto` to restart containers when env vars are changed
4. Max errors count and log level are being set as Helm values for visibility
5. Python code was formatted and linted
6. `process_block()` now tries to switch to `backup-rpc` when hits Exception communicating with `primary` one.